### PR TITLE
Added ability to configure a custom polling interval and set default …

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,16 +1,15 @@
 import { MirrorNode, NetworkType } from "./mirrorNode";
-import { ICache } from "./types/Cache";
-import { NameHash } from "./types/NameHash";
-import { SecondLevelDomain } from "./types/SecondLevelDomain";
+import { ICache, NameHash, ResolverOptions, SecondLevelDomain } from "./types";
 export declare const TEST_TLD_TOPIC_ID = "0.0.48097305";
 export declare const MAIN_TLD_TOPIC_ID = "0.0.1234189";
-export { ICache, Links, MessageObject, MessagesResponse, NFT, NFTsResponse, NameHash, SecondLevelDomain, TopLevelDomain, } from "./types";
+export { ICache, Links, MessageObject, MessagesResponse, NFT, NFTsResponse, NameHash, SecondLevelDomain, TopLevelDomain, ResolverOptions, } from "./types";
 export declare class Resolver {
     mirrorNode: MirrorNode;
+    private _options?;
     private _isCaughtUpWithTopic;
     private _subscriptions;
     private cache;
-    constructor(networkType: NetworkType, authKey?: string, cache?: ICache);
+    constructor(networkType: NetworkType, authKey?: string, cache?: ICache, options?: ResolverOptions);
     /**
      * @description Initializes all topic subscriptions.
      */

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,7 +8,7 @@ const pollingTopicSubscriber_1 = require("./topicSubscriber/pollingTopicSubscrib
 exports.TEST_TLD_TOPIC_ID = "0.0.48097305";
 exports.MAIN_TLD_TOPIC_ID = "0.0.1234189";
 class Resolver {
-    constructor(networkType, authKey = "", cache) {
+    constructor(networkType, authKey = "", cache, options) {
         this._isCaughtUpWithTopic = new Map();
         this._subscriptions = [];
         this.mirrorNode = new mirrorNode_1.MirrorNode(networkType, authKey);
@@ -17,6 +17,9 @@ class Resolver {
         }
         else {
             this.cache = cache;
+        }
+        if (options) {
+            this._options = options;
         }
     }
     /**
@@ -72,7 +75,7 @@ class Resolver {
             }, () => {
                 this._isCaughtUpWithTopic.set(this.getTldTopicId(), true);
                 resolve();
-            }, undefined, this.mirrorNode.authKey));
+            }, undefined, this.mirrorNode.authKey, this._options));
         });
     }
     /**
@@ -116,7 +119,7 @@ class Resolver {
             }, () => {
                 this._isCaughtUpWithTopic.set(topicId, true);
                 resolve();
-            }, undefined, this.mirrorNode.authKey));
+            }, undefined, this.mirrorNode.authKey, this._options));
         });
     }
     /**

--- a/dist/topicSubscriber/pollingTopicSubscriber.d.ts
+++ b/dist/topicSubscriber/pollingTopicSubscriber.d.ts
@@ -1,6 +1,7 @@
 import { NetworkType } from "../mirrorNode";
 import { MessageObject } from "../types/MessageObject";
+import { ResolverOptions } from "../types/ResolverOptions";
 export declare const executeWithRetriesAsync: <T>(func: (retryNum: number) => Promise<T>, shouldRetry: (err: any) => boolean, maxRetries?: number) => Promise<T>;
 export declare class PollingTopicSubscriber {
-    static subscribe(networkType: NetworkType, topicId: string, onMessage: (message: MessageObject) => void, onCaughtUp: () => void, startingTimestamp?: string, authKey?: string): () => void;
+    static subscribe(networkType: NetworkType, topicId: string, onMessage: (message: MessageObject) => void, onCaughtUp: () => void, startingTimestamp?: string, authKey?: string, options?: ResolverOptions): () => void;
 }

--- a/dist/topicSubscriber/pollingTopicSubscriber.js
+++ b/dist/topicSubscriber/pollingTopicSubscriber.js
@@ -38,7 +38,8 @@ const sendGetRequest = async (url, authKey) => {
     }, () => true);
 };
 class PollingTopicSubscriber {
-    static subscribe(networkType, topicId, onMessage, onCaughtUp, startingTimestamp = `000`, authKey) {
+    static subscribe(networkType, topicId, onMessage, onCaughtUp, startingTimestamp = `000`, authKey, options) {
+        const pollingInterval = options && options.pollingInterval ? options.pollingInterval : 60 * 1000;
         let lastTimestamp = startingTimestamp;
         let calledOnCaughtUp = false;
         let cancelled = false;
@@ -72,7 +73,22 @@ class PollingTopicSubscriber {
                     calledOnCaughtUp = true;
                 }
                 if (messages.length === 0) {
-                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                    await new Promise((resolve) => {
+                        let intervalHandle = undefined;
+                        let timeoutHandle = undefined;
+                        // This interval allows the promise to resolve early if the subscription is cancelled
+                        intervalHandle = setInterval(() => {
+                            if (cancelled) {
+                                resolve();
+                                clearTimeout(timeoutHandle);
+                            }
+                        }, 250);
+                        // This timeout will resolve the promise after the pollingInterval has ellapsed
+                        timeoutHandle = setTimeout(() => {
+                            resolve();
+                            clearInterval(intervalHandle);
+                        }, pollingInterval);
+                    });
                 }
                 else {
                     lastTimestamp = messages[messages.length - 1].consensus_timestamp;

--- a/dist/types/ResolverOptions.d.ts
+++ b/dist/types/ResolverOptions.d.ts
@@ -1,0 +1,3 @@
+export interface ResolverOptions {
+    pollingInterval?: number;
+}

--- a/dist/types/ResolverOptions.js
+++ b/dist/types/ResolverOptions.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -5,6 +5,7 @@ import MessagesResponse from './MessagesResponse';
 import { NameHash } from './NameHash';
 import { NFT } from './NFT';
 import { NFTsResponse } from './NFTsResponse';
+import { ResolverOptions } from './ResolverOptions';
 import { SecondLevelDomain } from './SecondLevelDomain';
 import { TopLevelDomain } from './TopLevelDomain';
-export { ICache, Links, MessageObject, MessagesResponse, NameHash, NFT, NFTsResponse, SecondLevelDomain, TopLevelDomain };
+export { ICache, Links, MessageObject, MessagesResponse, NameHash, NFT, NFTsResponse, SecondLevelDomain, TopLevelDomain, ResolverOptions };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,7 @@ import { hashDomain } from "./hashDomain";
 import { MemoryCache } from "./MemoryCache";
 import { MirrorNode, NetworkType } from "./mirrorNode";
 import { PollingTopicSubscriber } from "./topicSubscriber/pollingTopicSubscriber";
-import { ICache } from "./types/Cache";
-import { NameHash } from "./types/NameHash";
-import { SecondLevelDomain } from "./types/SecondLevelDomain";
-import { TopLevelDomain } from "./types/TopLevelDomain";
+import { ICache, NameHash, ResolverOptions, SecondLevelDomain, TopLevelDomain } from "./types";
 
 export const TEST_TLD_TOPIC_ID = "0.0.48097305";
 export const MAIN_TLD_TOPIC_ID = "0.0.1234189";
@@ -20,20 +17,26 @@ export {
   NameHash,
   SecondLevelDomain,
   TopLevelDomain,
+  ResolverOptions,
 } from "./types";
 
 export class Resolver {
   mirrorNode: MirrorNode;
+  private _options?: ResolverOptions;
   private _isCaughtUpWithTopic = new Map<string, boolean>();
   private _subscriptions: (() => void)[] = [];
   private cache: ICache;
 
-  constructor(networkType: NetworkType, authKey = "", cache?: ICache) {
+  constructor(networkType: NetworkType, authKey = "", cache?: ICache, options?: ResolverOptions) {
     this.mirrorNode = new MirrorNode(networkType, authKey);
     if (!cache) {
       this.cache = new MemoryCache();
     } else {
       this.cache = cache;
+    }
+
+    if (options) {
+      this._options = options;
     }
   }
 
@@ -104,7 +107,8 @@ export class Resolver {
             resolve();
           },
           undefined,
-          this.mirrorNode.authKey
+          this.mirrorNode.authKey,
+          this._options
         )
       );
     });
@@ -168,7 +172,8 @@ export class Resolver {
             resolve();
           },
           undefined,
-          this.mirrorNode.authKey
+          this.mirrorNode.authKey,
+          this._options
         )
       );
     });

--- a/src/topicSubscriber/pollingTopicSubscriber.ts
+++ b/src/topicSubscriber/pollingTopicSubscriber.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import { getBaseUrl, MAX_PAGE_SIZE, NetworkType } from "../mirrorNode";
 import { MessageObject } from "../types/MessageObject";
 import MessagesResponse from "../types/MessagesResponse";
+import { ResolverOptions } from "../types/ResolverOptions";
 
 export const executeWithRetriesAsync = async <T>(func: (retryNum: number) => Promise<T>, shouldRetry: (err: any) => boolean, maxRetries = 5): Promise<T> => {
   let retryNum = 0;
@@ -46,7 +47,10 @@ export class PollingTopicSubscriber {
     onCaughtUp: () => void,
     startingTimestamp: string = `000`,
     authKey?: string,
+    options?: ResolverOptions
   ): () => void {
+    const pollingInterval = options && options.pollingInterval ? options.pollingInterval : 60 * 1000;
+
     let lastTimestamp = startingTimestamp;
     let calledOnCaughtUp = false;
     let cancelled = false;
@@ -84,7 +88,24 @@ export class PollingTopicSubscriber {
         }
 
         if (messages.length === 0) {
-          await new Promise((resolve) => setTimeout(resolve, 1000));
+          await new Promise<void>((resolve) => {
+            let intervalHandle: NodeJS.Timeout | undefined = undefined;
+            let timeoutHandle: NodeJS.Timer | undefined = undefined;
+
+            // This interval allows the promise to resolve early if the subscription is cancelled
+            intervalHandle = setInterval(() => {
+              if (cancelled) {
+                resolve();
+                clearTimeout(timeoutHandle);
+              }
+            }, 250);
+
+            // This timeout will resolve the promise after the pollingInterval has ellapsed
+            timeoutHandle = setTimeout(() => {
+              resolve();
+              clearInterval(intervalHandle);
+            }, pollingInterval);
+          });
         } else {
           lastTimestamp = messages[messages.length - 1].consensus_timestamp;
         }

--- a/src/types/ResolverOptions.ts
+++ b/src/types/ResolverOptions.ts
@@ -1,0 +1,3 @@
+export interface ResolverOptions {
+  pollingInterval?: number
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ import MessagesResponse from './MessagesResponse';
 import { NameHash } from './NameHash';
 import { NFT } from './NFT';
 import { NFTsResponse } from './NFTsResponse';
+import { ResolverOptions } from './ResolverOptions';
 import { SecondLevelDomain } from './SecondLevelDomain';
 import { TopLevelDomain } from './TopLevelDomain';
 
@@ -17,5 +18,6 @@ export {
     NFT,
     NFTsResponse,
     SecondLevelDomain,
-    TopLevelDomain
+    TopLevelDomain,
+    ResolverOptions
 }


### PR DESCRIPTION
## Describe your changes
Allows configurable polling intervals.

The current settings poll the topic every 1000 ms. This is pretty frequent. The new default is to poll each topic every 60 seconds and allows this setting to be configured via the Resolver's constructor.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My changes generate no new warningss
- [x] Any dependent changes have been merged
- [x] Integration tests pass
- [x] Linters pass
- [x] Unit tests pass
